### PR TITLE
Simplify internal interface between TrainController and TrainParts

### DIFF
--- a/demo/custom_train_part.gd
+++ b/demo/custom_train_part.gd
@@ -1,0 +1,17 @@
+extends GenericTrainPart
+class_name CustomTrainPart
+
+var _total_time = 0.0
+var state = {
+    "custom_train_part_calls": 0,
+}
+
+func _process_train_part(delta):
+    _total_time += delta
+    if _total_time > 2:
+        _total_time = 0
+        print("Here is a custom train part")
+        state["custom_train_part_calls"] += 1
+
+func _get_train_part_state():
+    return state

--- a/demo/demo.gd
+++ b/demo/demo.gd
@@ -3,6 +3,10 @@ extends Control
 var _t:float = 0.0
 
 @onready var train = $SM42_V1
+@onready var brake = $SM42_V1/Brake
+@onready var engine = $SM42_V1/StonkaDieselEngine
+@onready var security = $SM42_V1/TrainSecuritySystem
+
 
 # Called when the node enters the scene tree for the first time.
 func _ready() -> void:
@@ -18,14 +22,7 @@ func draw_dictionary(dict: Dictionary, target: DebugPanel):
 func get_state_by_path(path):
     var _p = train.get_node(path) as TrainPart
     if _p:
-        return _p.get_mover_state(train)
-    else:
-        return {}
-
-func get_state_by_method(method):
-    var _p = Callable(train, "get_%s" % method).call() as TrainPart
-    if _p:
-        return _p.get_mover_state(train)
+        return _p.get_mover_state()
     else:
         return {}
 
@@ -39,14 +36,14 @@ func _process(delta: float) -> void:
         var train_state = train.get_mover_state()
         var bv = train_state.get("battery_voltage")
 
-
+        $%CustomTrainPartCount.text = "%s" % train.state.get("custom_train_part_calls")
 
         $%BatteryProgressBar.value = bv
         $%BatteryValue.text = "%.2f V" % [bv]
 
-        var security_state = get_state_by_method("security_system")
-        var brake_state = get_state_by_method("brake")
-        var engine_state = get_state_by_method("engine")
+        var security_state = security.get_mover_state()
+        var brake_state = brake.get_mover_state()
+        var engine_state = engine.get_mover_state()
 
         draw_dictionary(engine_state, $%DebugEngine)
         draw_dictionary(train_state, $%DebugTrain)
@@ -59,9 +56,7 @@ func _process(delta: float) -> void:
 
 
 func _on_brake_level_value_changed(value):
-    var b = train.get_brake() as TrainBrake
-    if b:
-        b.brake_level = value
+    brake.brake_level = value
 
 
 func _on_main_decrease_button_up():

--- a/demo/demo.tscn
+++ b/demo/demo.tscn
@@ -13,6 +13,8 @@ anchor_right = 1.0
 anchor_bottom = 1.0
 grow_horizontal = 2
 grow_vertical = 2
+size_flags_horizontal = 3
+size_flags_vertical = 3
 script = ExtResource("1_76ghk")
 
 [node name="EngineRPM" parent="." instance=ExtResource("3_dosfj")]
@@ -99,6 +101,16 @@ title = "Train"
 
 [node name="HBoxContainer" type="HBoxContainer" parent="UI"]
 layout_mode = 2
+size_flags_vertical = 0
+
+[node name="Label" type="Label" parent="UI/HBoxContainer"]
+layout_mode = 2
+text = "Custom train part calls count:"
+
+[node name="CustomTrainPartCount" type="Label" parent="UI/HBoxContainer"]
+unique_name_in_owner = true
+layout_mode = 2
+text = "0"
 
 [node name="MoverSwitches" type="HBoxContainer" parent="UI"]
 layout_mode = 2

--- a/demo/sm_42v_1.tscn
+++ b/demo/sm_42v_1.tscn
@@ -1,9 +1,8 @@
-[gd_scene format=3 uid="uid://c5hi8nsm1d2hb"]
+[gd_scene load_steps=2 format=3 uid="uid://c5hi8nsm1d2hb"]
+
+[ext_resource type="Script" path="res://custom_train_part.gd" id="1_2wure"]
 
 [node name="SM42v1" type="TrainController"]
-parts/engine = NodePath("StonkaDieselEngine")
-parts/brake = NodePath("Brake")
-parts/security_system = NodePath("TrainSecuritySystem")
 type_name = "6d"
 dimensions/mass = 74000.0
 power = 590.0
@@ -43,3 +42,6 @@ emergency_brake_delay = 2.5
 sound_signal_delay = 2.5
 shp_magnet_distance = 3.0
 ca_max_hold_time = 1.0
+
+[node name="CustomTrainPart" type="GenericTrainPart" parent="."]
+script = ExtResource("1_2wure")

--- a/src/core/GenericTrainPart.cpp
+++ b/src/core/GenericTrainPart.cpp
@@ -1,0 +1,43 @@
+#include <godot_cpp/classes/gd_extension.hpp>
+#include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/variant/utility_functions.hpp>
+
+#include "GenericTrainPart.hpp"
+
+namespace godot {
+    GenericTrainPart::GenericTrainPart() = default;
+
+    void GenericTrainPart::_bind_methods() {
+        ClassDB::bind_method(D_METHOD("get_train_controller_node"), &GenericTrainPart::get_train_controller_node);
+        ClassDB::bind_method(D_METHOD("get_train_state"), &GenericTrainPart::get_train_state);
+        BIND_VIRTUAL_METHOD(GenericTrainPart, _process_train_part);
+        BIND_VIRTUAL_METHOD(GenericTrainPart, _get_train_part_state);
+    }
+
+    void GenericTrainPart::_do_update_internal_mover(TMoverParameters *mover) {};
+    void GenericTrainPart::_do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) {};
+    void GenericTrainPart::_do_process_mover(TMoverParameters *mover, double delta) {};
+    void GenericTrainPart::_process_train_part(const double delta) {};
+    Dictionary GenericTrainPart::_get_train_part_state() {
+        return internal_state;
+    };
+    void GenericTrainPart::_process_mover(const double delta) {
+        call("_process_train_part", delta);
+        internal_state = call("_get_train_part_state");
+        train_controller_node->get_state().merge(internal_state, true);
+    };
+
+    TrainController *GenericTrainPart::get_train_controller_node() {
+        return train_controller_node;
+    }
+
+    Dictionary GenericTrainPart::get_train_state() {
+        if (train_controller_node != nullptr) {
+            return train_controller_node->get_state();
+        } else {
+            UtilityFunctions::push_error("GenericTrainPart has no train controller node");
+            return Dictionary();
+        }
+    }
+
+} // namespace godot

--- a/src/core/GenericTrainPart.hpp
+++ b/src/core/GenericTrainPart.hpp
@@ -1,0 +1,29 @@
+#include <godot_cpp/core/binder_common.hpp>
+#include <godot_cpp/core/gdvirtual.gen.inc>
+
+#include "TrainPart.hpp"
+
+namespace godot {
+    class GenericTrainPart : public TrainPart {
+            GDCLASS(GenericTrainPart, TrainPart)
+
+        private:
+            static void _bind_methods();
+            Dictionary internal_state;
+
+        protected:
+            void _do_update_internal_mover(TMoverParameters *mover) override;
+            void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state) override;
+            void _do_process_mover(TMoverParameters *mover, double delta) override;
+
+        public:
+            TrainController *get_train_controller_node();
+            void _process_mover(double delta) override;
+            virtual void _process_train_part(double delta);
+            virtual Dictionary _get_train_part_state();
+            Dictionary get_train_state();
+
+            GenericTrainPart();
+            ~GenericTrainPart() override = default;
+    };
+} // namespace godot

--- a/src/core/TrainController.hpp
+++ b/src/core/TrainController.hpp
@@ -10,6 +10,7 @@ namespace godot {
     class TrainSwitch;
     class TrainSecuritySystem;
 
+
     class TrainController final : public Node {
             GDCLASS(TrainController, Node)
         private:
@@ -24,6 +25,7 @@ namespace godot {
             Dictionary internal_state;
 
             bool sw_battery_enabled = false;
+            bool is_powered = false;
 
             double nominal_battery_voltage = 0.0; // FIXME: move to TrainPower ?
             double mass = 0.0;
@@ -31,7 +33,7 @@ namespace godot {
             double max_velocity = 0.0;
             String axle_arrangement = "";
 
-            void _collect_train_switches(const Node *node, Vector<TrainSwitch *> &train_switches);
+            void _collect_train_parts(const Node *node, Vector<TrainPart *> &train_parts);
             void _connect_signals_to_train_part(TrainPart *part);
 
             void _update_mover_config_if_dirty();
@@ -46,33 +48,21 @@ namespace godot {
             void _do_fetch_state_from_mover(TMoverParameters *mover, Dictionary &state);
             void _process_mover(double delta);
 
+
         public:
+            static const char *MOVER_CONFIG_CHANGED_SIGNAL;
+            static const char *POWER_CHANGED_SIGNAL;
+            static const char *COMMAND_RECEIVED;
+
             void _process(double delta) override;
             void _ready() override;
             Dictionary get_mover_state();
+            void send_command(StringName command, Variant p1 = Variant(), Variant p2 = Variant());
             void update_mover() const;
             void _on_train_part_config_changed(TrainPart *part) const;
 
             TMoverParameters *get_mover() const;
             static void _bind_methods();
-
-            NodePath engine_path;
-            mutable TrainEngine *_engine;
-            void set_engine_path(const NodePath &p_path);
-            NodePath get_engine_path() const;
-            TrainEngine *get_engine() const;
-
-            NodePath brake_path;
-            mutable TrainBrake *_brake;
-            void set_brake_path(const NodePath &p_path);
-            NodePath get_brake_path() const;
-            TrainBrake *get_brake() const;
-
-            NodePath security_system_path;
-            mutable TrainSecuritySystem *_security_system;
-            void set_security_system_path(const NodePath &p_path);
-            NodePath get_security_system_path() const;
-            TrainSecuritySystem *get_security_system() const;
 
             String get_type_name() const;
             void set_type_name(const String &type_name);
@@ -96,8 +86,6 @@ namespace godot {
             void main_controller_decrease();
             void forwarder_increase();
             void forwarder_decrease();
-
-            Vector<TrainSwitch *> get_train_switches();
 
             TrainController();
             ~TrainController() override = default;

--- a/src/core/TrainPart.cpp
+++ b/src/core/TrainPart.cpp
@@ -9,7 +9,15 @@ namespace godot {
         ClassDB::bind_method(D_METHOD("emit_config_changed_signal"), &TrainPart::emit_config_changed_signal);
         ClassDB::bind_method(D_METHOD("update_mover"), &TrainPart::update_mover);
         ClassDB::bind_method(D_METHOD("get_mover_state"), &TrainPart::get_mover_state);
+
+        ClassDB::bind_method(D_METHOD("set_enabled"), &TrainPart::set_enabled);
+        ClassDB::bind_method(D_METHOD("get_enabled"), &TrainPart::get_enabled);
+        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "get_enabled");
+
         ADD_SIGNAL(MethodInfo("config_changed"));
+        ADD_SIGNAL(MethodInfo("enable_changed", PropertyInfo(Variant::BOOL, "enabled")));
+        ADD_SIGNAL(MethodInfo("train_part_enabled"));
+        ADD_SIGNAL(MethodInfo("train_part_disabled"));
     }
 
     TrainPart::TrainPart() = default;
@@ -26,23 +34,76 @@ namespace godot {
         emit_signal("config_changed");
     }
 
-    void TrainPart::_process(double delta) {
-        if (_dirty) {
-            emit_config_changed_signal();
-            _dirty = false;
+    void TrainPart::_enter_tree() {
+        if (Engine::get_singleton()->is_editor_hint()) {
+            return;
+        }
+        Node *p = get_parent();
+        while (p != nullptr) {
+            train_controller_node = Object::cast_to<TrainController>(p);
+            if (train_controller_node != nullptr) {
+                break;
+            }
+            p = p->get_parent();
+        }
+        if (train_controller_node != nullptr) {
+            train_controller_node->connect(
+                    TrainController::MOVER_CONFIG_CHANGED_SIGNAL, Callable(this, "update_mover"));
         }
     }
 
-    void TrainPart::_process_mover(const TrainController *train_controller_node, double delta) {
+    void TrainPart::_exit_tree() {
+        if (Engine::get_singleton()->is_editor_hint()) {
+            return;
+        }
+        if (train_controller_node != nullptr) {
+            train_controller_node->disconnect(
+                    TrainController::MOVER_CONFIG_CHANGED_SIGNAL, Callable(this, "update_mover"));
+        }
+        train_controller_node = nullptr;
+    }
+
+    void TrainPart::_process(double delta) {
+        if (Engine::get_singleton()->is_editor_hint()) {
+            return;
+        }
+
+        if (!get_enabled()) {
+            if(enabled_changed) {
+                enabled_changed = false;
+                emit_signal("enable_changed", false);
+                emit_signal("train_part_disabled");
+            }
+
+            return;
+        }
+
+        if (_dirty) {
+            // emit_config_changed_signal();
+            update_mover();
+            _dirty = false;
+        }
+
+        _process_mover(delta);
+
+        if(enabled_changed) {
+            enabled_changed = false;
+            emit_signal("enable_changed", enabled);
+            emit_signal(enabled ? "train_part_enabled" : "train_part_disabled");
+        }
+    }
+
+    void TrainPart::_process_mover(double delta) {
         if (train_controller_node != nullptr) {
             TMoverParameters *mover = train_controller_node->get_mover();
             if (mover != nullptr) {
                 _do_process_mover(mover, delta);
+                train_controller_node->get_state().merge(get_mover_state(), true);
             }
         }
     }
 
-    void TrainPart::update_mover(const TrainController *train_controller_node) {
+    void TrainPart::update_mover() {
         if (train_controller_node != nullptr) {
             TMoverParameters *mover = train_controller_node->get_mover();
             if (mover != nullptr) {
@@ -55,7 +116,10 @@ namespace godot {
         }
     }
 
-    Dictionary TrainPart::get_mover_state(const TrainController *train_controller_node) {
+    Dictionary TrainPart::get_mover_state() {
+        if(!get_enabled()) {
+            return state;
+        }
         if (train_controller_node != nullptr) {
             TMoverParameters *mover = train_controller_node->get_mover();
             if (mover != nullptr) {
@@ -69,4 +133,13 @@ namespace godot {
         return state;
     }
 
+    void TrainPart::set_enabled(bool p_value) {
+        enabled_changed = (enabled != p_value);
+        enabled = p_value;
+        _dirty = true;
+    }
+
+    bool TrainPart::get_enabled() {
+        return enabled;
+    }
 } // namespace godot

--- a/src/core/TrainPart.hpp
+++ b/src/core/TrainPart.hpp
@@ -7,10 +7,15 @@ namespace godot {
             GDCLASS(TrainPart, Node)
         public:
             static void _bind_methods();
+
+        private:
             Dictionary state;
 
         protected:
+            bool enabled = true;
+            bool enabled_changed = false;
             bool _dirty = false;
+            TrainController *train_controller_node;
 
             /* Jesli bedzie potrzeba rozdzielenia etapow inicjalizacji movera od jego aktualizacji,
              * to ta metoda powinna byc zaimplementowana analogicznie do _do_update_internal_mover(),
@@ -36,8 +41,13 @@ namespace godot {
 
         public:
             void _ready() override;
+            void _enter_tree() override;
+            void _exit_tree() override;
             void _process(double delta) override;
-            void _process_mover(const TrainController *train_controller_node, double delta);
+            virtual void _process_mover(double delta);
+
+            void set_enabled(bool p_value);
+            bool get_enabled();
 
             /* Jesli bedzie potrzeba rozdzielenia etapow inicjalizacji movera od jego aktualizacji,
              * to ta metoda powinna byc zaimplementowana analogicznie do update_mover(),
@@ -45,10 +55,10 @@ namespace godot {
             // void initialize_mover(TrainController *train_controller_node);
 
             /* High level method for updating the state of the Mover */
-            void update_mover(const TrainController *train_controller_node);
+            void update_mover();
 
             /* High level method for getting the state of the Mover */
-            Dictionary get_mover_state(const TrainController *train_controller_node);
+            Dictionary get_mover_state();
             TrainPart();
             ~TrainPart() override = default;
             void emit_config_changed_signal();

--- a/src/register_types.cpp
+++ b/src/register_types.cpp
@@ -6,12 +6,14 @@
 
 #include "brakes/TrainBrake.hpp"
 #include "core/TrainController.hpp"
+
+#include "core/GenericTrainPart.hpp"
+#include "core/TrainPart.hpp"
+#include "core/TrainSwitch.hpp"
 #include "engines/TrainDieselEngine.hpp"
 #include "engines/TrainElectricEngine.hpp"
 #include "engines/TrainElectricSeriesEngine.hpp"
 #include "engines/TrainEngine.hpp"
-#include "core/TrainPart.hpp"
-#include "core/TrainSwitch.hpp"
 #include "systems/TrainSecuritySystem.hpp"
 
 using namespace godot;
@@ -22,6 +24,7 @@ void initialize_libmaszyna_module(ModuleInitializationLevel p_level) {
     }
 
     GDREGISTER_ABSTRACT_CLASS(TrainPart);
+    GDREGISTER_CLASS(GenericTrainPart);
     GDREGISTER_CLASS(TrainBrake);
     GDREGISTER_ABSTRACT_CLASS(TrainEngine);
     GDREGISTER_CLASS(TrainDieselEngine);

--- a/src/systems/TrainSecuritySystem.cpp
+++ b/src/systems/TrainSecuritySystem.cpp
@@ -35,10 +35,6 @@ namespace godot {
         ADD_PROPERTY(
                 PropertyInfo(Variant::BOOL, "aware_system/sifa"), "set_aware_system_sifa", "get_aware_system_sifa");
 
-        ClassDB::bind_method(D_METHOD("get_enabled"), &TrainSecuritySystem::get_enabled);
-        ClassDB::bind_method(D_METHOD("set_enabled"), &TrainSecuritySystem::set_enabled);
-        ADD_PROPERTY(PropertyInfo(Variant::BOOL, "enabled"), "set_enabled", "get_enabled");
-
         ClassDB::bind_method(D_METHOD("get_aware_delay"), &TrainSecuritySystem::get_aware_delay);
         ClassDB::bind_method(D_METHOD("set_aware_delay"), &TrainSecuritySystem::set_aware_delay);
         ADD_PROPERTY(PropertyInfo(Variant::FLOAT, "aware_delay"), "set_aware_delay", "get_aware_delay");
@@ -121,9 +117,6 @@ namespace godot {
     double TrainSecuritySystem::get_ca_max_hold_time() const {
         return ca_max_hold_time;
     }
-    bool TrainSecuritySystem::get_enabled() const {
-        return enabled;
-    }
 
     // Setters
     void TrainSecuritySystem::set_reset_pushed(bool p_state) {
@@ -172,10 +165,6 @@ namespace godot {
     }
     void TrainSecuritySystem::set_ca_max_hold_time(double value) {
         ca_max_hold_time = value;
-        _dirty = true;
-    }
-    void TrainSecuritySystem::set_enabled(bool p_state) {
-        enabled = p_state;
         _dirty = true;
     }
 

--- a/src/systems/TrainSecuritySystem.hpp
+++ b/src/systems/TrainSecuritySystem.hpp
@@ -23,8 +23,6 @@ namespace godot {
             ~TrainSecuritySystem() override = default;
 
         private:
-            bool enabled = true;
-
             bool aware_system_active = false;
             bool aware_system_cabsignal = false;
             bool aware_system_separate_acknowledge = false;
@@ -55,7 +53,6 @@ namespace godot {
             double get_sound_signal_delay() const;
             double get_shp_magnet_distance() const;
             double get_ca_max_hold_time() const;
-            bool get_enabled() const;
 
             // Setters
             void set_reset_pushed(bool p_state);
@@ -70,7 +67,6 @@ namespace godot {
             void set_sound_signal_delay(double value);
             void set_shp_magnet_distance(double value);
             void set_ca_max_hold_time(double value);
-            void set_enabled(bool value);
     };
 } // namespace godot
 VARIANT_ENUM_CAST(TrainSecuritySystem::EmergencyBrakeWarningSignal)


### PR DESCRIPTION
* adds `TrainPart.enabled` instead of assigning specific nodes via path
* eliminates the need to handle each part separately in the controller
* simplifies the high-level interface for accessing the mover state
* adds `GenericTrainPart` to implement train parts directly in GDScript (for those parts that don't require access to Mover)

To handle the logic of the `GenericTrainPart` the `_process_train_part(delta)` should be implemented in a custom script, but overriding `_process(delta)` is also possible.